### PR TITLE
Added a sidebar section for a used machine list.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -132,6 +132,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -452,6 +453,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -500,30 +502,9 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
-      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.3",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
-      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2184,7 +2165,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2205,7 +2185,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2254,8 +2233,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2371,6 +2349,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2381,6 +2360,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2430,6 +2410,7 @@
       "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.4",
         "@typescript-eslint/types": "8.59.4",
@@ -3178,6 +3159,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3218,7 +3200,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3552,6 +3533,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3812,6 +3794,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4009,7 +3992,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4042,8 +4024,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4314,6 +4295,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4515,6 +4497,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6261,7 +6244,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6856,7 +6838,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6872,7 +6853,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6885,8 +6865,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -6945,6 +6924,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7738,6 +7718,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7956,6 +7937,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8116,6 +8098,7 @@
       "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -8526,6 +8509,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/FactoryPlannerApp.tsx
+++ b/src/components/FactoryPlannerApp.tsx
@@ -393,7 +393,7 @@ function ColumnWorkspace({ workspace, onLoadDatasetVersion }: WorkspaceProps) {
         {workspace.rightPanelOpen ? (
           <InspectorPanel />
         ) : (
-          <PanelRail side="right" label="Resources" />
+          <PanelRail side="right" label="Resources and machines" />
         )}
       </main>
     </>
@@ -424,7 +424,7 @@ function CompactWorkspace({ workspace, onLoadDatasetVersion }: WorkspaceProps) {
       </PanelDrawer>
       <PanelDrawer
         side="right"
-        label="resources"
+        label="resources and machines"
         open={workspace.rightPanelOpen}
         onOpen={openRight}
         onClose={() => writeWorkspaceView({ rightPanelOpen: false })}

--- a/src/components/InspectorPanel.test.tsx
+++ b/src/components/InspectorPanel.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { gtnhFuelProfiles } from "@/lib/model/fuels";
 import {
@@ -8,6 +8,7 @@ import {
   type FactoryProject,
   type ResourceBalance,
 } from "@/lib/model/types";
+import { openInspectorTab, takePendingInspectorTab } from "@/lib/inspector-tab";
 import { calculateThroughput } from "@/lib/solver";
 import { closeBoundaries } from "@/lib/solver/close-boundaries";
 import { useFactoryStore } from "@/store/factory-store";
@@ -118,9 +119,12 @@ describe("InspectorPanel", () => {
   // This project's vitest config sets neither `globals` nor a setup file, so
   // testing-library's automatic cleanup never registers and renders would
   // otherwise pile up in the same document.
-  afterEach(cleanup);
+  afterEach(() => {
+    takePendingInspectorTab();
+    cleanup();
+  });
 
-  it("shows all four groups at once, without tab switching", () => {
+  it("shows the three flow groups on Resources without another switch", () => {
     seedResult({
       externalInputs: [makeBalance(1, { deficitPerSecond: 240 })],
       unconsumedOutputs: [makeBalance(2, { producedPerSecond: 64, surplusPerSecond: 64 })],
@@ -130,27 +134,24 @@ describe("InspectorPanel", () => {
     render(<InspectorPanel />);
 
     expect(screen.getByText("Inputs")).toBeDefined();
-    expect(screen.getByText("Products")).toBeDefined();
-    expect(screen.getByText("Byproducts")).toBeDefined();
+    expect(screen.getByText("Outputs")).toBeDefined();
     expect(screen.getByText("Internal")).toBeDefined();
     expect(screen.getByText("Resource 1")).toBeDefined();
     expect(screen.getByText("Resource 2")).toBeDefined();
+    // Internal starts folded: the header is there, the long tail is not.
+    expect(screen.queryByText("Internal 3")).toBeNull();
+    fireEvent.click(screen.getByText("Internal").closest("button")!);
     expect(screen.getByText("Internal 3")).toBeDefined();
   });
 
-  // Nothing left over is a byproduct: it is coming out and no product drawer
-  // claimed it. Calling it a product because a drawer has not been placed yet
-  // would decide what the factory is for on the reader's behalf.
-  it("files unclaimed spare output under byproducts", () => {
+  it("files unclaimed spare output under Outputs", () => {
     seedResult({
       unconsumedOutputs: [makeBalance(2, { producedPerSecond: 64, surplusPerSecond: 64 })],
     });
 
     render(<InspectorPanel />);
 
-    const headers = screen.getAllByText(/^(Products|Byproducts)$/).map((el) => el.textContent);
-    expect(headers).toEqual(["Products", "Byproducts"]);
-    expect(screen.getByText("Nothing asked for yet.")).toBeDefined();
+    expect(screen.getByText("Outputs")).toBeDefined();
     expect(screen.getByText("Resource 2")).toBeDefined();
   });
 
@@ -173,6 +174,7 @@ describe("InspectorPanel", () => {
       seedResult({ internal: Array.from({ length: 400 }, (_, index) => makeInternal(index, 100)) });
 
       const { container } = render(<InspectorPanel />);
+      fireEvent.click(screen.getByText("Internal").closest("button")!);
       const rowCount = container.querySelectorAll("[data-resource-row]").length;
 
       // 600px of viewport over 30px rows is ~20 visible, plus overscan at each end.
@@ -195,15 +197,18 @@ describe("InspectorPanel", () => {
     });
   });
 
-  it("collapses a section to its header", () => {
-    seedResult({ internal: [makeInternal(1, 100), makeInternal(2, 200)] });
+  it("collapses a section to its header", async () => {
+    seedResult({
+      externalInputs: [makeBalance(1, { deficitPerSecond: 100 }), makeBalance(2, { deficitPerSecond: 50 })],
+    });
 
     render(<InspectorPanel />);
-    expect(screen.getByText("Internal 1")).toBeDefined();
+    expect(screen.getByText("Resource 1")).toBeDefined();
 
-    fireEvent.click(screen.getByText("Internal").closest("button")!);
-    expect(screen.queryByText("Internal 1")).toBeNull();
-    expect(screen.getByText("Internal")).toBeDefined();
+    fireEvent.click(screen.getByText("Inputs").closest("button")!);
+    // Rows fold out on the presence clock instead of vanishing on the click.
+    await waitFor(() => expect(screen.queryByText("Resource 1")).toBeNull());
+    expect(screen.getByText("Inputs")).toBeDefined();
   });
 
   it("keeps section counts on the header while filtering", () => {
@@ -222,7 +227,7 @@ describe("InspectorPanel", () => {
   it("explains an empty group rather than showing a blank area", () => {
     render(<InspectorPanel />);
     expect(screen.getByText(/Nothing missing/)).toBeDefined();
-    expect(screen.getByText(/Nothing left over/)).toBeDefined();
+    expect(screen.getByText(/Nothing coming out yet/)).toBeDefined();
   });
 
   it("lights a resource on the canvas while it is pointed at", () => {
@@ -326,8 +331,9 @@ describe("InspectorPanel", () => {
       render(<InspectorPanel />);
 
       expect(screen.queryByText("Selection")).toBeNull();
-      // Made and eaten in-plan, so it sits under Internal, not Need.
       expect(screen.getByText("Ore")).toBeDefined();
+      // Made and eaten in-plan, so it sits under Internal, which starts folded.
+      fireEvent.click(screen.getByText("Internal").closest("button")!);
       expect(screen.getByText("Ingot")).toBeDefined();
     });
 
@@ -354,6 +360,100 @@ describe("InspectorPanel", () => {
       // The mode has to be readable from anywhere in the list, so the ring
       // belongs to the panel that wraps every group.
       expect(container.querySelector("section.ring-purple-500\\/60")).not.toBeNull();
+    });
+  });
+
+  describe("Machines tab", () => {
+    function seedMachines() {
+      const project: FactoryProject = {
+        schemaVersion: PROJECT_SCHEMA_VERSION,
+        id: "panel-machines-project",
+        name: "Panel machines",
+        recipes: [
+          {
+            id: "mac",
+            name: "Macerate",
+            machineType: "Macerator",
+            minimumTier: "LV",
+            durationTicks: 20,
+            eut: 30,
+            inputs: [{ kind: "item", id: "cobble", amount: 1, displayName: "Cobble" }],
+            outputs: [{ kind: "item", id: "gravel", amount: 1, displayName: "Gravel" }],
+          },
+        ],
+        nodes: [
+          {
+            id: "one",
+            recipeId: "mac",
+            machineCount: 2,
+            parallel: 1,
+            overclockTier: "LV",
+            enabled: true,
+            position: { x: 0, y: 0 },
+          },
+          {
+            id: "two",
+            recipeId: "mac",
+            machineCount: 4,
+            parallel: 1,
+            overclockTier: "LV",
+            enabled: true,
+            position: { x: 200, y: 0 },
+          },
+        ],
+        edges: [],
+        fuelProfiles: gtnhFuelProfiles,
+        selectedFuelProfileId: "biodiesel",
+      };
+
+      useFactoryStore.setState({
+        project,
+        lastResult: calculateThroughput(project, { generatedAt: "fixed" }),
+        selectedBoardIds: [],
+        hoveredUsageNodeIds: undefined,
+      });
+    }
+
+    it("starts on Resources and opens a stacked machine list from Machines", () => {
+      seedMachines();
+      render(<InspectorPanel />);
+
+      expect(screen.getByText("Inputs")).toBeDefined();
+      expect(screen.queryByText("LV Macerator")).toBeNull();
+
+      fireEvent.click(screen.getByRole("button", { name: "Machines" }));
+
+      expect(screen.getByText("LV Macerator")).toBeDefined();
+      expect(screen.getByText("6×")).toBeDefined();
+      expect(screen.queryByText("Inputs")).toBeNull();
+    });
+
+    it("opens Machines when asked from outside, including before mount", async () => {
+      seedMachines();
+      openInspectorTab("machines");
+      render(<InspectorPanel />);
+
+      expect(screen.getByText("LV Macerator")).toBeDefined();
+      expect(screen.queryByText("Inputs")).toBeNull();
+
+      openInspectorTab("resources");
+      await waitFor(() => {
+        expect(screen.getByText("Inputs")).toBeDefined();
+      });
+      expect(screen.queryByText("LV Macerator")).toBeNull();
+    });
+
+    it("lights every card in a stack while the row is pointed at", () => {
+      seedMachines();
+      render(<InspectorPanel />);
+      fireEvent.click(screen.getByRole("button", { name: "Machines" }));
+
+      const row = screen.getByText("LV Macerator").closest("[data-machine-row]")!;
+      fireEvent.mouseEnter(row);
+
+      const hovered = useFactoryStore.getState().hoveredUsageNodeIds;
+      expect(hovered?.has("one")).toBe(true);
+      expect(hovered?.has("two")).toBe(true);
     });
   });
 });

--- a/src/components/InspectorPanel.tsx
+++ b/src/components/InspectorPanel.tsx
@@ -27,6 +27,11 @@ import { selectTrendSeries, useResourceTrends } from "@/lib/resource-trends";
 import { useFactoryStore } from "@/store/factory-store";
 import { useDebouncedValue } from "@/lib/hooks/use-debounced-value";
 import {
+  OPEN_INSPECTOR_TAB_EVENT,
+  takePendingInspectorTab,
+  type InspectorTab,
+} from "@/lib/inspector-tab";
+import {
   toggleResourceFavourite,
   toggleResourceHidden,
   useWorkspaceView,
@@ -49,7 +54,16 @@ import {
 } from "./inspector/flow-sections";
 import { TrendSparkline } from "./inspector/TrendSparkline";
 import { MotionNumberText, runMotionTween, useBoardMotion } from "./flow/board-motion";
+import { useMachineHandlerIcons } from "./flow/machine-icons";
 import { ResourceIcon } from "./nei/ResourceIcon";
+import {
+  buildMachineRoster,
+  filterMachineRoster,
+  resolveMachineRosterNodeIds,
+  totalMachineCount,
+  type MachineRosterIcon,
+  type MachineRosterRow,
+} from "./inspector/machine-roster";
 
 const FLOW_FILTER_DEBOUNCE_MS = 120;
 const SELECTION_DEBOUNCE_MS = 100;
@@ -282,15 +296,121 @@ function useRowPresence(targetRows: FlowRow[], enabled: boolean): RowPresence {
 }
 
 export function InspectorPanel() {
+  // A request that arrived before this column was mounted (a phone's drawer is
+  // unmounted while closed) is waiting in module state, so the tab it asked for
+  // is collected here as well as by the listener below.
+  const [tab, setTab] = useState<InspectorTab>(() => takePendingInspectorTab() ?? "resources");
+  const setHoveredUsageNodeIds = useFactoryStore((state) => state.setHoveredUsageNodeIds);
+
+  useEffect(() => {
+    if (tab !== "machines") {
+      setHoveredUsageNodeIds(undefined);
+    }
+  }, [setHoveredUsageNodeIds, tab]);
+
+  useEffect(() => {
+    const openTab = () => {
+      const next = takePendingInspectorTab();
+      if (next) {
+        setTab(next);
+      }
+    };
+    window.addEventListener(OPEN_INSPECTOR_TAB_EVENT, openTab);
+    return () => window.removeEventListener(OPEN_INSPECTOR_TAB_EVENT, openTab);
+  }, []);
+
   return (
     <aside
       data-help-anchor="inspector"
       className="flex h-full min-h-[360px] compact:min-h-0 flex-col bg-surface"
     >
+      {/*
+        Same column chrome as the left sidebar: a head row so the tabs sit
+        level with the board toolbar, then a flat strip that swaps the whole
+        panel. The hide button lives here so Machines has a way out too.
+      */}
+      <div className="flex h-8 shrink-0 items-center border-b border-line px-2 compact:hidden">
+        <HideColumnButton className="ml-auto" />
+      </div>
+      <div className="flex shrink-0 border-b border-line">
+        <InspectorTabButton
+          current={tab}
+          value="resources"
+          label="Resources"
+          onSelect={setTab}
+        />
+        <InspectorTabButton
+          current={tab}
+          value="machines"
+          label="Machines"
+          onSelect={setTab}
+        />
+        <HideColumnButton className="hidden h-7 w-8 shrink-0 items-center justify-center border-b-2 border-transparent text-fg-muted compact:flex" />
+      </div>
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden p-2">
-        <FlowIOPanel />
+        {tab === "machines" ? <MachineRosterPanel /> : <FlowIOPanel />}
       </div>
     </aside>
+  );
+}
+
+function InspectorTabButton({
+  current,
+  value,
+  label,
+  onSelect,
+}: {
+  current: InspectorTab;
+  value: InspectorTab;
+  label: string;
+  onSelect: (tab: InspectorTab) => void;
+}) {
+  const selected = current === value;
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(value)}
+      data-tour-anchor={value === "machines" ? "machines-tab" : "resources-tab"}
+      aria-pressed={selected}
+      className={[
+        "flex h-7 flex-1 items-center justify-center gap-1 border-b-2 text-[11px] font-medium",
+        selected
+          ? "border-cyan-400 text-cyan-300"
+          : "border-transparent text-fg-muted hover:text-fg",
+      ].join(" ")}
+    >
+      {value === "machines" ? <CogGlyph /> : <PackageGlyph />}
+      {label}
+    </button>
+  );
+}
+
+function HideColumnButton({ className }: { className?: string }) {
+  return (
+    <button
+      type="button"
+      onClick={() => writeWorkspaceView({ rightPanelOpen: false })}
+      title="Hide this column"
+      aria-label="Hide the resources and machines column"
+      className={[
+        "flex h-6 w-6 shrink-0 items-center justify-center rounded border border-line-strong text-fg-muted hover:border-cyan-600 hover:text-cyan-400",
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      <svg
+        viewBox="0 0 16 16"
+        className="h-3.5 w-3.5"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M6 3l5 5-5 5" />
+      </svg>
+    </button>
   );
 }
 
@@ -641,29 +761,6 @@ function FlowIOPanel() {
               {hiddenCount} hidden
             </span>
           ) : null}
-
-          <button
-            type="button"
-            onClick={() => writeWorkspaceView({ rightPanelOpen: false })}
-            title="Hide this column"
-            aria-label="Hide the resources column"
-            className={[
-              "flex h-6 w-6 shrink-0 items-center justify-center rounded border border-line-strong text-fg-muted hover:border-cyan-600 hover:text-cyan-400",
-              hiddenCount > 0 ? "" : "ml-auto",
-            ].join(" ")}
-          >
-            <svg
-              viewBox="0 0 16 16"
-              className="h-3.5 w-3.5"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.8"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M6 3l5 5-5 5" />
-            </svg>
-          </button>
         </div>
 
         <div className="relative">
@@ -1696,4 +1793,202 @@ function buildProjectResourceLookup(project: FactoryProject): Map<string, FlowRe
   }
 
   return resources;
+}
+
+/**
+ * The Machines tab: one stacked row per placed machine at a voltage, same
+ * card and selection ring the resource lists wear. Resource-only chrome
+ * (stars, hide, RAW/NET, charts) stays on that tab.
+ */
+function MachineRosterPanel() {
+  const project = useFactoryStore((state) => state.project);
+  const selectedBoardIds = useFactoryStore((state) => state.selectedBoardIds);
+  const focusBoardNode = useFactoryStore((state) => state.focusBoardNode);
+  const hoveredUsageNodeIds = useFactoryStore((state) => state.hoveredUsageNodeIds);
+  const setHoveredUsageNodeIds = useFactoryStore((state) => state.setHoveredUsageNodeIds);
+  const handlerIcons = useMachineHandlerIcons();
+  const [filter, setFilter] = useState("");
+  const debouncedFilter = useDebouncedValue(filter, FLOW_FILTER_DEBOUNCE_MS);
+
+  const scopedIds = useMemo(
+    () => resolveMachineRosterNodeIds(project, selectedBoardIds),
+    [project, selectedBoardIds],
+  );
+  const icons = useMemo(() => {
+    const map = new Map<string, MachineRosterIcon>();
+    for (const [id, resource] of handlerIcons) {
+      map.set(id, { ...resource, amount: resource.amount ?? 1 });
+    }
+    return map;
+  }, [handlerIcons]);
+  const rows = useMemo(
+    () => buildMachineRoster(project, { nodeIds: scopedIds, icons }),
+    [icons, project, scopedIds],
+  );
+  const visible = useMemo(
+    () => filterMachineRoster(rows, debouncedFilter),
+    [debouncedFilter, rows],
+  );
+  const isFiltered = debouncedFilter.trim().length > 0;
+  const total = totalMachineCount(rows);
+  const matchCount = visible.length;
+
+  const focusStepRef = useRef(new Map<string, number>());
+  const focusBoardOnRow = useCallback(
+    (row: MachineRosterRow) => {
+      if (row.nodeIds.length === 0) {
+        return;
+      }
+      const step = focusStepRef.current.get(row.key) ?? 0;
+      focusStepRef.current.set(row.key, step + 1);
+      focusBoardNode(row.nodeIds[step % row.nodeIds.length]!);
+    },
+    [focusBoardNode],
+  );
+
+  useEffect(
+    () => () => {
+      setHoveredUsageNodeIds(undefined);
+    },
+    [setHoveredUsageNodeIds],
+  );
+
+  const selection =
+    scopedIds === undefined
+      ? undefined
+      : {
+          machineCount: project.nodes.filter((node) => scopedIds.has(node.id)).length,
+          storageCount: (project.storages ?? []).filter((storage) => scopedIds.has(storage.id))
+            .length,
+        };
+
+  return (
+    <section
+      className={[
+        "flex min-h-0 flex-1 flex-col rounded border bg-surface-raised",
+        selection ? "border-purple-500 ring-1 ring-purple-500/60" : "border-line",
+      ].join(" ")}
+    >
+      {selection ? (
+        <ScopeStrip
+          machineCount={selection.machineCount}
+          storageCount={selection.storageCount}
+        />
+      ) : null}
+
+      <div className="shrink-0 border-b border-line p-1">
+        <div className="relative">
+          <input
+            value={filter}
+            onChange={(event) => setFilter(event.target.value)}
+            placeholder="Filter machines…"
+            aria-label="Filter machines"
+            className="h-9 w-full rounded border border-line-strong bg-surface pl-2 pr-14 text-base text-fg outline-none placeholder:text-fg-muted focus:border-cyan-600 focus:ring-1 focus:ring-cyan-300"
+          />
+          {filter ? (
+            <button
+              type="button"
+              onClick={() => setFilter("")}
+              aria-label="Clear filter"
+              className="absolute right-1 top-1/2 -translate-y-1/2 rounded px-1.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-fg-muted hover:bg-surface-sunken hover:text-fg"
+            >
+              {matchCount} ✕
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+        <div
+          style={{ height: ROW_HEIGHTS.header }}
+          className="sticky top-0 z-10 flex w-full items-center gap-2 border-y border-line bg-surface-sunken/90 px-2 text-left text-fg-subtle backdrop-blur-sm"
+        >
+          <span className="text-sm font-bold uppercase tracking-wider">Machines</span>
+          <span className="rounded bg-fg-muted/20 px-1.5 py-0.5 text-xs font-bold tabular-nums text-fg-subtle">
+            {isFiltered ? `${totalMachineCount(visible)} / ${total}` : total}
+          </span>
+        </div>
+
+        {visible.length === 0 ? (
+          <p
+            style={{ height: ROW_HEIGHTS.empty }}
+            className="flex items-center px-3 text-xs text-fg-muted"
+          >
+            <span className="truncate">
+              {isFiltered ? "No matches." : "No machines on the board."}
+            </span>
+          </p>
+        ) : (
+          visible.map((row) => {
+            const isActive = row.nodeIds.some((id) => hoveredUsageNodeIds?.has(id));
+            return (
+              <div
+                key={row.key}
+                data-machine-row={row.key}
+                style={{ height: ROW_HEIGHTS.item }}
+                className="px-1"
+                onMouseEnter={() => setHoveredUsageNodeIds(row.nodeIds)}
+                onMouseLeave={() => setHoveredUsageNodeIds(undefined)}
+              >
+                <button
+                  type="button"
+                  onFocus={() => setHoveredUsageNodeIds(row.nodeIds)}
+                  onBlur={() => setHoveredUsageNodeIds(undefined)}
+                  onDoubleClick={() => focusBoardOnRow(row)}
+                  style={{ gridTemplateColumns: `${ICON_COLUMN} minmax(0,1fr) auto` }}
+                  className={[
+                    "grid h-full w-full items-center rounded pr-1 text-left",
+                    isActive
+                      ? "bg-cyan-500/10 ring-1 ring-cyan-500/60"
+                      : "hover:bg-cyan-500/10 hover:ring-1 hover:ring-cyan-500/60",
+                  ].join(" ")}
+                >
+                  <span
+                    style={{ height: ROW_HEIGHTS.item, width: ROW_HEIGHTS.item }}
+                    className="flex shrink-0 items-center justify-center overflow-hidden"
+                  >
+                    {row.icon ? (
+                      <ResourceIcon
+                        resource={row.icon}
+                        size="sm"
+                        showAmount={false}
+                        bare
+                        tooltip={false}
+                        className="!h-full !w-full"
+                      />
+                    ) : null}
+                  </span>
+                  <span className="ml-2 min-w-0 truncate text-base font-medium text-fg">
+                    {row.label}
+                  </span>
+                  <span className="shrink-0 pl-2 text-sm font-bold tabular-nums text-fg">
+                    {row.machineCount}×
+                  </span>
+                </button>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </section>
+  );
+}
+
+function PackageGlyph() {
+  return (
+    <svg viewBox="0 0 16 16" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M2.5 5.5 8 3l5.5 2.5L8 8 2.5 5.5Z" />
+      <path d="M2.5 5.5V11L8 13.5V8" />
+      <path d="M13.5 5.5V11L8 13.5" />
+    </svg>
+  );
+}
+
+function CogGlyph() {
+  return (
+    <svg viewBox="0 0 16 16" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <circle cx="8" cy="8" r="2" />
+      <path d="M8 2.5v1.5M8 12v1.5M2.5 8H4M12 8h1.5M4.1 4.1l1.1 1.1M10.8 10.8l1.1 1.1M11.9 4.1l-1.1 1.1M5.2 10.8l-1.1 1.1" />
+    </svg>
+  );
 }

--- a/src/components/flow/BoardHelp.tsx
+++ b/src/components/flow/BoardHelp.tsx
@@ -218,6 +218,7 @@ const CALLOUTS: Array<{
       { chip: "INPUTS", tone: "need", text: "Bring this in yourself" },
       { chip: "OUTPUTS", tone: "output", text: "Leaves the plan" },
       { chip: "INTERNAL", tone: "internal", text: "Made and used here" },
+      { text: "Machines adds up every machine the plan needs" },
       { text: "Hover a row to light up the board" },
     ],
   },

--- a/src/components/flow/FactoryFlow.tsx
+++ b/src/components/flow/FactoryFlow.tsx
@@ -1458,7 +1458,7 @@ export function FactoryFlow() {
   const selectedFlowResourceKey = useFactoryStore((state) => state.selectedFlowResourceKey);
   const hoveredNodeBottlenecks = useFactoryStore((state) => state.hoveredNodeBottlenecks);
   const selectedNodeBottlenecks = useFactoryStore((state) => state.selectedNodeBottlenecks);
-  const hoveredUsageNodeId = useFactoryStore((state) => state.hoveredUsageNodeId);
+  const hoveredUsageNodeIds = useFactoryStore((state) => state.hoveredUsageNodeIds);
   const recipeSearch = useFactoryStore((state) => state.highlightSearch);
   const isProjectImporting = useFactoryStore((state) => state.isProjectImporting);
   // The side panel's question: hover or click a resource row and every wire and
@@ -1564,7 +1564,7 @@ export function FactoryFlow() {
           type: "recipeNode",
           position: node.position,
           zIndex:
-            hoveredUsageNodeId === node.id
+            hoveredUsageNodeIds?.has(node.id)
               ? 1500
               : activeNodeBottlenecks && result.nodes[node.id]?.status === "bottleneck"
                 ? 1500
@@ -1653,7 +1653,7 @@ export function FactoryFlow() {
       activeFlowResourceKey,
       activeNodeBottlenecks,
       activePocketId,
-      hoveredUsageNodeId,
+      hoveredUsageNodeIds,
       pocketRails,
       pocketSummaries,
       pocketView.visiblePockets,

--- a/src/components/flow/RecipeNode.tsx
+++ b/src/components/flow/RecipeNode.tsx
@@ -183,7 +183,7 @@ function RecipeNodeComponent({ data, selected }: NodeProps<RecipeFlowNode>) {
   const isNodeBottleneckHighlighted =
     (hoveredNodeBottlenecks || selectedNodeBottlenecks) && result?.status === "bottleneck";
   const isUsageHighlighted = useFactoryStore(
-    (state) => state.hoveredUsageNodeId === projectNode.id,
+    (state) => state.hoveredUsageNodeIds?.has(projectNode.id) === true,
   );
   const isInspectorHighlighted =
     isFlowResourceHighlighted || isNodeBottleneckHighlighted || isUsageHighlighted;

--- a/src/components/flow/flow-explainers.test.ts
+++ b/src/components/flow/flow-explainers.test.ts
@@ -232,7 +232,7 @@ describe("explainPort — inputs", () => {
     );
     const story = explainPort(proj, result, "N", rails.inputs[0]!, verdict);
 
-    expect(story.stateWord).toBe("BOTTLENECK");
+    expect(story.stateWord).toBe("STARVED");
     expect(story.lines[0]).toContain("Gets");
     expect(story.lines[0]).toContain("from Cracker");
     expect(story.lines[0]).toContain("holds the machine at");

--- a/src/components/flow/flow-explainers.test.ts
+++ b/src/components/flow/flow-explainers.test.ts
@@ -201,7 +201,7 @@ describe("explainPort — inputs", () => {
     );
   });
 
-  it("still names the feeder when that maker is starving too", () => {
+  it("points one step further up when the maker is starving too", () => {
     const proj = project({
       recipes: [
         { id: "r", name: "M", machineType: "M", minimumTier: "ULV", durationTicks: 20, eut: 1, inputs: [], outputs: [] },

--- a/src/components/flow/flow-explainers.test.ts
+++ b/src/components/flow/flow-explainers.test.ts
@@ -148,7 +148,7 @@ describe("format helpers", () => {
   it("suppresses numbers below the display noise floor", () => {
     expect(formatSlotRateOrNull(0.0002, "fluid")).toBeNull();
     expect(formatSlotRateOrNull(0, "item")).toBeNull();
-    expect(formatSlotRateOrNull(0.5, "item")).toBe("0.50/s");
+    expect(formatSlotRateOrNull(0.5, "item")).toBe("0.5/s");
   });
 
   it("formats ask multipliers compactly, with real magnitudes up to four digits", () => {
@@ -195,14 +195,13 @@ describe("explainPort — inputs", () => {
     );
     const story = explainPort(proj, result, "LCR", rails.inputs[0]!, verdict);
 
-    expect(story.stateWord).toBe("BOTTLENECK");
-    expect(story.lines[0]).toBe("Bottleneck: gets 5.14 L/s of 32.0 L/s — machine at 16%.");
-    // No fix line any more: the hover names the state and the reason, and the
-    // card's own marks say where to act.
-    expect(story.lines[0]).toContain("holds the machine at");
+    expect(story.stateWord).toBe("STARVED");
+    expect(story.lines[0]).toBe(
+      "Gets 5.14 L/s of the 32 L/s it wants from Distillation Tower. This is what holds the machine at 16%.",
+    );
   });
 
-  it("points one step further up when the maker is starving too", () => {
+  it("still names the feeder when that maker is starving too", () => {
     const proj = project({
       recipes: [
         { id: "r", name: "M", machineType: "M", minimumTier: "ULV", durationTicks: 20, eut: 1, inputs: [], outputs: [] },
@@ -235,7 +234,8 @@ describe("explainPort — inputs", () => {
 
     expect(story.stateWord).toBe("BOTTLENECK");
     expect(story.lines[0]).toContain("Gets");
-    expect(story.stateWord).toBe("BLOCKED");
+    expect(story.lines[0]).toContain("from Cracker");
+    expect(story.lines[0]).toContain("holds the machine at");
   });
 
   it("clears the innocent input and warns about the next bottleneck", () => {
@@ -346,9 +346,7 @@ describe("explainPlug — the asker's side", () => {
     expect(rails.outputs[0]!.plug?.state).toBe("hungry");
     expect(rails.outputs[0]!.plug?.askerName).toBe("LCR");
     expect(story.stateWord).toBe("HUNGRY");
-    expect(story.lines[0]).toBe("16% = asked 32.0 L/s, this puts in 5.14 L/s.");
-    expect(story.lines[0]).toContain("Asked");
-    expect(story.lines[0]).toContain("gets");
+    expect(story.lines[0]).toBe("Asked 32 L/s, gets 5.14 L/s (LCR).");
   });
 
   it("reads blocked-upstream when the machine is starving itself", () => {
@@ -637,7 +635,7 @@ describe("buildEdgeStory", () => {
     expect(story?.from.name).toBe("Distillation Tower");
     expect(story?.from.note).toBe("at full speed");
     expect(story?.to[0]?.name).toBe("LCR");
-    expect(story?.to[0]?.text).toContain("wants 32.0 L/s, gets 5.14 L/s");
+    expect(story?.to[0]?.text).toContain("wants 32 L/s, gets 5.14 L/s");
     expect(story?.lines[0]).toContain("covers only 16% of what the LCR wants");
     expect(story?.action?.text).toBe("→ Add +6 Distillation Tower.");
   });
@@ -670,7 +668,7 @@ describe("buildEdgeStory", () => {
     );
     const story = buildEdgeStory(proj, result, ["e1"]);
 
-    expect(story?.to[0]?.text).toContain("its share of 32.0 L/s over 2 lines");
+    expect(story?.to[0]?.text).toContain("its share of 32 L/s over 2 lines");
   });
 
   it("keeps buffer lines dead simple", () => {
@@ -690,7 +688,7 @@ describe("buildEdgeStory", () => {
 
     expect(story?.stateWord).toBe("TO BUFFER");
     expect(story?.to[0]?.name).toBe("PE Drawer (product)");
-    expect(story?.lines[0]).toBe("Flows into the buffer at 3.00/s.");
+    expect(story?.lines[0]).toBe("Flows into the buffer at 3/s.");
   });
 
   it("reports spare capacity on a satisfied single-outlet line", () => {
@@ -715,8 +713,8 @@ describe("buildEdgeStory", () => {
     const story = buildEdgeStory(proj, result, ["eOut"]);
 
     expect(story?.stateWord).toBe("OK");
-    expect(story?.lines[0]).toBe("Delivers exactly what's asked: 4.00/s.");
-    expect(story?.lines[1]).toContain("could send 10.0/s, with 6.00/s spare");
+    expect(story?.lines[0]).toBe("Delivers exactly what's asked: 4/s.");
+    expect(story?.lines[1]).toContain("could send 10/s, with 6/s spare");
     expect(story?.from.note).toContain("could send more if asked");
   });
 });

--- a/src/components/inspector/machine-roster.test.ts
+++ b/src/components/inspector/machine-roster.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from "vitest";
+import { CUSTOM_RATE_MACHINE_TYPE } from "@/lib/model/custom-rate";
+import { PROJECT_SCHEMA_VERSION, type FactoryNode, type FactoryProject, type Recipe } from "@/lib/model/types";
+import { TRASH_MACHINE_TYPE } from "@/lib/model/trash";
+import { gtnhFuelProfiles } from "@/lib/model/fuels";
+import {
+  buildMachineRoster,
+  filterMachineRoster,
+  resolveMachineRosterNodeIds,
+  totalMachineCount,
+  type MachineRosterIcon,
+} from "./machine-roster";
+
+function makeNode(
+  id: string,
+  recipeId: string,
+  overrides: Partial<FactoryNode> = {},
+): FactoryNode {
+  return {
+    id,
+    recipeId,
+    machineCount: 1,
+    parallel: 1,
+    overclockTier: "LV",
+    enabled: true,
+    position: { x: 0, y: 0 },
+    ...overrides,
+  };
+}
+
+function makeRecipe(
+  id: string,
+  machineType: string,
+  overrides: Partial<Recipe> = {},
+): Recipe {
+  return {
+    id,
+    name: `${machineType} recipe`,
+    machineType,
+    minimumTier: "LV",
+    durationTicks: 20,
+    eut: 30,
+    inputs: [],
+    outputs: [{ kind: "item", id: `${id}-out`, amount: 1, displayName: "Output" }],
+    ...overrides,
+  };
+}
+
+describe("buildMachineRoster", () => {
+  it("stacks the same machine at the same voltage into one row", () => {
+    const rows = buildMachineRoster({
+      nodes: [
+        makeNode("a", "mac", { machineCount: 2 }),
+        makeNode("b", "mac", { machineCount: 4 }),
+      ],
+      recipes: [makeRecipe("mac", "Macerator")],
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.label).toBe("LV Macerator");
+    expect(rows[0]?.machineCount).toBe(6);
+    expect(rows[0]?.nodeIds).toEqual(["a", "b"]);
+  });
+
+  it("keeps the same machine at two voltages as two rows", () => {
+    const rows = buildMachineRoster({
+      nodes: [
+        makeNode("lv", "mac", { overclockTier: "LV", machineCount: 3 }),
+        makeNode("hv", "mac", { overclockTier: "HV", machineCount: 1 }),
+      ],
+      recipes: [makeRecipe("mac", "Macerator")],
+    });
+
+    expect(rows.map((row) => row.label)).toEqual(["LV Macerator", "HV Macerator"]);
+    expect(rows.map((row) => row.machineCount)).toEqual([3, 1]);
+  });
+
+  it("does not merge distinct machine families", () => {
+    const rows = buildMachineRoster({
+      nodes: [makeNode("cr", "chem"), makeNode("lcr", "large")],
+      recipes: [
+        makeRecipe("chem", "Chemical Reactor", {
+          machineHandlers: [
+            {
+              id: "chemical-reactor",
+              label: "Chemical Reactor",
+              machineType: "Chemical Reactor",
+              minimumTier: "LV",
+            },
+          ],
+        }),
+        makeRecipe("large", "Large Chemical Reactor", {
+          machineHandlers: [
+            {
+              id: "large-chemical-reactor",
+              label: "Large Chemical Reactor",
+              machineType: "Large Chemical Reactor",
+              minimumTier: "HV",
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(rows.map((row) => row.machineName).sort()).toEqual([
+      "Chemical Reactor",
+      "Large Chemical Reactor",
+    ]);
+  });
+
+  it("skips disabled cards, trash cans and custom-rate sources", () => {
+    const rows = buildMachineRoster({
+      nodes: [
+        makeNode("on", "mac"),
+        makeNode("off", "mac", { enabled: false }),
+        makeNode("bin", "trash"),
+        makeNode("dial", "custom"),
+        makeNode("gone", "missing"),
+      ],
+      recipes: [
+        makeRecipe("mac", "Macerator"),
+        makeRecipe("trash", TRASH_MACHINE_TYPE, { eut: 0 }),
+        makeRecipe("custom", CUSTOM_RATE_MACHINE_TYPE, { eut: 0 }),
+      ],
+    });
+
+    expect(rows.map((row) => row.nodeIds)).toEqual([["on"]]);
+  });
+
+  it("keeps crop farms and drops the voltage prefix on steam and untimed machines", () => {
+    const rows = buildMachineRoster({
+      nodes: [
+        makeNode("farm", "crop", { overclockTier: "LV" }),
+        makeNode("steam", "steam-mac", { overclockTier: "LV" }),
+        makeNode("table", "craft", { overclockTier: "LV" }),
+      ],
+      recipes: [
+        makeRecipe("crop", "Crop Farm", { kind: "crop_produce", eut: 0 }),
+        makeRecipe("steam-mac", "Steam Macerator", {
+          eut: 0,
+          machineHandlers: [
+            {
+              id: "steam-macerator",
+              label: "Steam Macerator",
+              machineType: "Steam Macerator",
+              minimumTier: "LV",
+            },
+          ],
+        }),
+        makeRecipe("craft", "Crafting", { eut: 0 }),
+      ],
+    });
+
+    expect(rows.map((row) => row.label).sort()).toEqual([
+      "Crafting",
+      "Crop Farm",
+      "Steam Macerator",
+    ]);
+  });
+
+  it("prefers the dataset's machine icon and falls back to the first output", () => {
+    const machineIcon: MachineRosterIcon = {
+      kind: "item",
+      id: "machine.macerator",
+      amount: 1,
+      displayName: "Macerator",
+    };
+    const rows = buildMachineRoster(
+      {
+        nodes: [makeNode("a", "mac"), makeNode("b", "chem")],
+        recipes: [
+          makeRecipe("mac", "Macerator", {
+            machineHandlers: [
+              {
+                id: "macerator",
+                label: "Macerator",
+                machineType: "Macerator",
+                minimumTier: "LV",
+              },
+            ],
+          }),
+          makeRecipe("chem", "Chemical Reactor"),
+        ],
+      },
+      { icons: new Map([["macerator", machineIcon]]) },
+    );
+
+    expect(rows.find((row) => row.handlerId === "macerator")?.icon?.id).toBe("machine.macerator");
+    expect(rows.find((row) => row.label.includes("Chemical"))?.icon?.id).toBe("chem-out");
+  });
+
+  it("sorts the busiest stack first and names as a tie break", () => {
+    const rows = buildMachineRoster({
+      nodes: [
+        makeNode("few", "bender", { machineCount: 1 }),
+        makeNode("many", "mac", { machineCount: 8 }),
+        makeNode("also-one", "lathe", { machineCount: 1 }),
+      ],
+      recipes: [
+        makeRecipe("mac", "Macerator"),
+        makeRecipe("bender", "Bending Machine"),
+        makeRecipe("lathe", "Lathe"),
+      ],
+    });
+
+    expect(rows.map((row) => row.machineName)).toEqual([
+      "Macerator",
+      "Bending Machine",
+      "Lathe",
+    ]);
+  });
+
+  it("can be limited to a set of cards", () => {
+    const rows = buildMachineRoster(
+      {
+        nodes: [
+          makeNode("keep", "mac", { machineCount: 2 }),
+          makeNode("drop", "mac", { machineCount: 9 }),
+        ],
+        recipes: [makeRecipe("mac", "Macerator")],
+      },
+      { nodeIds: new Set(["keep"]) },
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.machineCount).toBe(2);
+    expect(rows[0]?.nodeIds).toEqual(["keep"]);
+  });
+});
+
+describe("filterMachineRoster", () => {
+  it("matches the printed label, the machine name, or the voltage", () => {
+    const rows = buildMachineRoster({
+      nodes: [
+        makeNode("lv", "mac", { overclockTier: "LV" }),
+        makeNode("hv", "chem", { overclockTier: "HV" }),
+      ],
+      recipes: [makeRecipe("mac", "Macerator"), makeRecipe("chem", "Chemical Reactor")],
+    });
+
+    expect(filterMachineRoster(rows, "macer").map((row) => row.machineName)).toEqual(["Macerator"]);
+    expect(filterMachineRoster(rows, "hv").map((row) => row.tier)).toEqual(["HV"]);
+    expect(filterMachineRoster(rows, "nope")).toEqual([]);
+  });
+});
+
+describe("resolveMachineRosterNodeIds", () => {
+  const project: FactoryProject = {
+    schemaVersion: PROJECT_SCHEMA_VERSION,
+    id: "roster-scope",
+    name: "Roster scope",
+    recipes: [makeRecipe("mac", "Macerator")],
+    nodes: [makeNode("smelter", "mac"), makeNode("bender", "mac")],
+    edges: [],
+    storages: [
+      {
+        id: "chest",
+        kind: "item" as const,
+        resourceId: "ingot",
+        position: { x: 0, y: 0 },
+      },
+    ],
+    fuelProfiles: gtnhFuelProfiles,
+    selectedFuelProfileId: "biodiesel",
+  };
+
+  it("treats an empty selection as the whole plan", () => {
+    expect(resolveMachineRosterNodeIds(project, [])).toBeUndefined();
+  });
+
+  it("treats a drawers-only selection as the whole plan", () => {
+    expect(resolveMachineRosterNodeIds(project, ["chest"])).toBeUndefined();
+  });
+
+  it("keeps a machine selection, pockets included", () => {
+    const scoped = resolveMachineRosterNodeIds(project, ["bender"]);
+    expect(scoped?.has("bender")).toBe(true);
+    expect(scoped?.has("smelter")).toBe(false);
+  });
+});
+
+describe("totalMachineCount", () => {
+  it("sums the stacked counts", () => {
+    expect(
+      totalMachineCount([
+        { machineCount: 4 } as never,
+        { machineCount: 2 } as never,
+      ]),
+    ).toBe(6);
+  });
+});

--- a/src/components/inspector/machine-roster.test.ts
+++ b/src/components/inspector/machine-roster.test.ts
@@ -71,8 +71,8 @@ describe("buildMachineRoster", () => {
       recipes: [makeRecipe("mac", "Macerator")],
     });
 
-    expect(rows.map((row) => row.label)).toEqual(["LV Macerator", "HV Macerator"]);
-    expect(rows.map((row) => row.machineCount)).toEqual([3, 1]);
+    expect(rows.map((row) => row.label)).toEqual(["HV Macerator", "LV Macerator"]);
+    expect(rows.map((row) => row.machineCount)).toEqual([1, 3]);
   });
 
   it("does not merge distinct machine families", () => {
@@ -189,24 +189,40 @@ describe("buildMachineRoster", () => {
     expect(rows.find((row) => row.label.includes("Chemical"))?.icon?.id).toBe("chem-out");
   });
 
-  it("sorts the busiest stack first and names as a tie break", () => {
+  it("sorts highest voltage first, then the busiest stack, then the machine name", () => {
     const rows = buildMachineRoster({
       nodes: [
-        makeNode("few", "bender", { machineCount: 1 }),
-        makeNode("many", "mac", { machineCount: 8 }),
-        makeNode("also-one", "lathe", { machineCount: 1 }),
+        makeNode("hv-many", "chem", { overclockTier: "HV", machineCount: 8 }),
+        makeNode("lv-few", "bender", { overclockTier: "LV", machineCount: 1 }),
+        makeNode("lv-many", "mac", { overclockTier: "LV", machineCount: 8 }),
+        makeNode("lv-also-one", "lathe", { overclockTier: "LV", machineCount: 1 }),
+        makeNode("steam", "steam-mac", { overclockTier: "LV", machineCount: 20 }),
       ],
       recipes: [
+        makeRecipe("chem", "Chemical Reactor"),
         makeRecipe("mac", "Macerator"),
         makeRecipe("bender", "Bending Machine"),
         makeRecipe("lathe", "Lathe"),
+        makeRecipe("steam-mac", "Steam Macerator", {
+          eut: 0,
+          machineHandlers: [
+            {
+              id: "steam-macerator",
+              label: "Steam Macerator",
+              machineType: "Steam Macerator",
+              minimumTier: "LV",
+            },
+          ],
+        }),
       ],
     });
 
-    expect(rows.map((row) => row.machineName)).toEqual([
-      "Macerator",
-      "Bending Machine",
-      "Lathe",
+    expect(rows.map((row) => row.label)).toEqual([
+      "HV Chemical Reactor",
+      "LV Macerator",
+      "LV Bending Machine",
+      "LV Lathe",
+      "Steam Macerator",
     ]);
   });
 

--- a/src/components/inspector/machine-roster.ts
+++ b/src/components/inspector/machine-roster.ts
@@ -114,10 +114,14 @@ export function buildMachineRoster(
   }
 
   return [...groups.values()].sort((left, right) => {
+    const tierDelta = rosterTierIndex(left.tier) - rosterTierIndex(right.tier);
+    if (tierDelta !== 0) {
+      return tierDelta;
+    }
     if (right.machineCount !== left.machineCount) {
       return right.machineCount - left.machineCount;
     }
-    return left.label.localeCompare(right.label);
+    return left.machineName.localeCompare(right.machineName);
   });
 }
 
@@ -147,6 +151,15 @@ export function totalMachineCount(rows: Iterable<MachineRosterRow>): number {
     total += row.machineCount;
   }
   return total;
+}
+
+/** MAX…ULV, then steam/crafting/untimed (no voltage) after the last real tier. */
+function rosterTierIndex(tier: string | undefined): number {
+  if (!tier) {
+    return GT_VOLTAGE_TIERS.length;
+  }
+  const index = GT_VOLTAGE_TIERS.findIndex((entry) => entry.tier === tier);
+  return index === -1 ? GT_VOLTAGE_TIERS.length : GT_VOLTAGE_TIERS.length - 1 - index;
 }
 
 function rosterVoltageTier(

--- a/src/components/inspector/machine-roster.ts
+++ b/src/components/inspector/machine-roster.ts
@@ -1,0 +1,184 @@
+import { isCustomRateRecipe } from "@/lib/model/custom-rate";
+import { expandPocketSelection } from "@/lib/model/pocket-connections";
+import {
+  getSelectedMachineHandler,
+  isSteamMachineHandler,
+} from "@/lib/model/recipe-rules";
+import { GT_VOLTAGE_TIERS } from "@/lib/model/tiers";
+import { isTrashRecipe } from "@/lib/model/trash";
+import type { FactoryProject, ResourceAmount } from "@/lib/model/types";
+
+const VOLTAGE_TIER_SET = new Set<string>(GT_VOLTAGE_TIERS.map((entry) => entry.tier));
+
+/** Icon fields ResourceIcon needs; handler-family icons and recipe outputs both fit. */
+export type MachineRosterIcon = Pick<
+  ResourceAmount,
+  "kind" | "id" | "amount" | "displayName" | "iconPath" | "iconAtlas" | "dominantColor"
+>;
+
+/**
+ * One shopping-list row: every enabled card that is the same placed machine
+ * at the same voltage, stacked. Two Chemical Reactors doing different recipes
+ * still merge if they are the same handler and tier — you place one machine
+ * type. Large Chemical Reactor stays its own row.
+ */
+export interface MachineRosterRow {
+  key: string;
+  /** What the list prints, e.g. "HV Chemical Reactor". */
+  label: string;
+  machineName: string;
+  /** Voltage tier when the machine actually uses one. Steam and crafting omit it. */
+  tier?: string;
+  handlerId: string;
+  machineCount: number;
+  /** Board cards in this stack, in project order, for hover and double-click. */
+  nodeIds: string[];
+  icon?: MachineRosterIcon;
+}
+
+/**
+ * Which cards the Machines tab should count.
+ *
+ * Empty selection, or a selection of nothing but drawers, means the whole
+ * plan — the same rule the resource lists already use. Selecting a pocket
+ * counts everything inside it.
+ */
+export function resolveMachineRosterNodeIds(
+  project: FactoryProject,
+  selectedIds: readonly string[],
+): ReadonlySet<string> | undefined {
+  if (selectedIds.length === 0) {
+    return undefined;
+  }
+
+  const { itemIds } = expandPocketSelection(project, selectedIds);
+  const hasMachine = project.nodes.some((node) => itemIds.has(node.id));
+  return hasMachine ? itemIds : undefined;
+}
+
+/**
+ * Totals every placeable machine on the board (or in `nodeIds`).
+ *
+ * Disabled cards, trash cans and custom-rate sources are not machines you
+ * craft, so they stay out. Crop farms stay in. Counts are the node's own
+ * `machineCount`, floored at zero.
+ */
+export function buildMachineRoster(
+  project: Pick<FactoryProject, "nodes" | "recipes">,
+  options?: {
+    nodeIds?: ReadonlySet<string>;
+    icons?: ReadonlyMap<string, MachineRosterIcon>;
+  },
+): MachineRosterRow[] {
+  const recipesById = new Map(project.recipes.map((recipe) => [recipe.id, recipe]));
+  const groups = new Map<string, MachineRosterRow>();
+
+  for (const node of project.nodes) {
+    if (options?.nodeIds && !options.nodeIds.has(node.id)) {
+      continue;
+    }
+    if (!node.enabled) {
+      continue;
+    }
+
+    const recipe = recipesById.get(node.recipeId);
+    if (!recipe || isTrashRecipe(recipe) || isCustomRateRecipe(recipe)) {
+      continue;
+    }
+
+    const handler = getSelectedMachineHandler(recipe, node);
+    const machineName = handler.label || recipe.machineType || recipe.name;
+    const tier = rosterVoltageTier(node.overclockTier, handler, handler.eut ?? recipe.eut);
+    const key = `${handler.id}:${tier ?? ""}`;
+    const count = Math.max(0, node.machineCount);
+    const existing = groups.get(key);
+    if (existing) {
+      existing.machineCount += count;
+      existing.nodeIds.push(node.id);
+      if (!existing.icon) {
+        existing.icon = rosterIcon(handler.id, recipe, options?.icons);
+      }
+      continue;
+    }
+
+    groups.set(key, {
+      key,
+      label: tier ? `${tier} ${machineName}` : machineName,
+      machineName,
+      tier,
+      handlerId: handler.id,
+      machineCount: count,
+      nodeIds: [node.id],
+      icon: rosterIcon(handler.id, recipe, options?.icons),
+    });
+  }
+
+  return [...groups.values()].sort((left, right) => {
+    if (right.machineCount !== left.machineCount) {
+      return right.machineCount - left.machineCount;
+    }
+    return left.label.localeCompare(right.label);
+  });
+}
+
+export function filterMachineRoster(rows: MachineRosterRow[], filter: string): MachineRosterRow[] {
+  const normalized = filter.trim().toLowerCase();
+  if (!normalized) {
+    return rows;
+  }
+
+  return rows.filter((row) => {
+    if (row.label.toLowerCase().includes(normalized)) {
+      return true;
+    }
+    if (row.machineName.toLowerCase().includes(normalized)) {
+      return true;
+    }
+    if (row.tier && row.tier.toLowerCase().includes(normalized)) {
+      return true;
+    }
+    return row.handlerId.toLowerCase().includes(normalized);
+  });
+}
+
+export function totalMachineCount(rows: Iterable<MachineRosterRow>): number {
+  let total = 0;
+  for (const row of rows) {
+    total += row.machineCount;
+  }
+  return total;
+}
+
+function rosterVoltageTier(
+  overclockTier: string,
+  handler: { label: string },
+  eut: number,
+): string | undefined {
+  if (isSteamMachineHandler(handler) || !(eut > 0)) {
+    return undefined;
+  }
+  return VOLTAGE_TIER_SET.has(overclockTier) ? overclockTier : undefined;
+}
+
+function rosterIcon(
+  handlerId: string,
+  recipe: { outputs: ResourceAmount[] },
+  icons?: ReadonlyMap<string, MachineRosterIcon>,
+): MachineRosterIcon | undefined {
+  const family = icons?.get(handlerId);
+  if (family) {
+    return { ...family, amount: family.amount ?? 1 };
+  }
+  const output = recipe.outputs[0];
+  return output
+    ? {
+        kind: output.kind,
+        id: output.id,
+        amount: 1,
+        displayName: output.displayName,
+        iconPath: output.iconPath,
+        iconAtlas: output.iconAtlas,
+        dominantColor: output.dominantColor,
+      }
+    : undefined;
+}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -73,6 +73,15 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "2.15.0",
+    date: "2026-08-16",
+    headline: "A Machines tab that totals what machines are needed",
+    notes: [
+      "Changed Resources to Resources and Machines, which adds a summary of all required machines in a new tab.",
+      "Hover a row to light those machines; double-click goes to that machine, if multiple cycles through.",
+    ],
+  },
+  {
     version: "2.14.1",
     date: "2026-08-14",
     headline: "The site introduces itself to AI assistants",

--- a/src/lib/inspector-tab.ts
+++ b/src/lib/inspector-tab.ts
@@ -1,0 +1,26 @@
+/**
+ * Landing the right column on Resources or Machines from anywhere else in the
+ * app.
+ *
+ * Same bargain as `sidebar-tab.ts`: the panel may not be mounted when the
+ * request is made (on a phone it is a closed drawer), so the wanted tab waits
+ * in module state until either the mounted panel's listener or the next mount
+ * collects it.
+ */
+export const OPEN_INSPECTOR_TAB_EVENT = "gtnh:open-inspector-tab";
+
+export type InspectorTab = "resources" | "machines";
+
+let pendingTab: InspectorTab | undefined;
+
+export function openInspectorTab(tab: InspectorTab): void {
+  pendingTab = tab;
+  window.dispatchEvent(new Event(OPEN_INSPECTOR_TAB_EVENT));
+}
+
+/** One-shot read of the tab the last request asked for, if any. */
+export function takePendingInspectorTab(): InspectorTab | undefined {
+  const tab = pendingTab;
+  pendingTab = undefined;
+  return tab;
+}

--- a/src/lib/tour/lessons.ts
+++ b/src/lib/tour/lessons.ts
@@ -27,6 +27,7 @@ import {
   User,
 } from "lucide-react";
 import type { GlanceRow } from "@/components/tour/card-parts";
+import { openInspectorTab } from "@/lib/inspector-tab";
 import { openSidebarTab } from "@/lib/sidebar-tab";
 import { writeWorkspaceView } from "@/lib/workspace-view";
 import {
@@ -155,6 +156,14 @@ function showSidebarTab(tab: "items" | "blueprints" | "setups") {
   };
 }
 
+/** Open the right column AND land it on one tab: Resources, then Machines. */
+function showInspectorTab(tab: "resources" | "machines") {
+  return () => {
+    showColumn("right");
+    openInspectorTab(tab);
+  };
+}
+
 const LOOK_AROUND: TourLesson = {
   id: "look-around",
   title: "A look around the planner",
@@ -223,7 +232,7 @@ const LOOK_AROUND: TourLesson = {
     {
       anchor: "inspector",
       side: "left",
-      before: () => showColumn("right"),
+      before: showInspectorTab("resources"),
       title: "What the plan needs",
       rows: [
         { text: "Fills with three lists once machines are on the board." },
@@ -231,6 +240,17 @@ const LOOK_AROUND: TourLesson = {
         { chip: "OUTPUTS", tone: "output", text: "This leaves the plan." },
         { chip: "INTERNAL", tone: "internal", text: "Made and used right here." },
         { text: "Hover a row and every card carrying it *lights up*." },
+      ],
+    },
+    {
+      anchor: "inspector",
+      side: "left",
+      before: showInspectorTab("machines"),
+      title: "A list of all machines used",
+      rows: [
+        { text: "One row per *machine at a voltage*. Same ones stack." },
+        { text: "Hover a row and those cards *light up*." },
+        { mouse: "left", text: "Double click *flies the board* to them." },
       ],
     },
     {

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -16,4 +16,4 @@
  * `src/lib/changelog.ts` written for players, not for developers, and kept to
  * a headline plus a few one-line notes.
  */
-export const APP_VERSION = "2.14.1";
+export const APP_VERSION = "2.15.0";

--- a/src/store/factory-store.ts
+++ b/src/store/factory-store.ts
@@ -167,8 +167,8 @@ interface FactoryStore {
   };
   hoveredNodeBottlenecks: boolean;
   selectedNodeBottlenecks: boolean;
-  /** Node hovered in the inspector's usage grid, highlighted on the canvas. */
-  hoveredUsageNodeId?: string;
+  /** Cards hovered in the inspector's Machines list, highlighted on the canvas. */
+  hoveredUsageNodeIds?: ReadonlySet<string>;
   flowViewportCenter?: FactoryNode["position"];
   selectedNodeId?: string;
   selectedRecipeId?: string;
@@ -210,7 +210,7 @@ interface FactoryStore {
   selectFlowResourceKey: (key?: string) => void;
   setHoveredNodeBottlenecks: (isHovered: boolean) => void;
   toggleNodeBottlenecks: () => void;
-  setHoveredUsageNodeId: (nodeId?: string) => void;
+  setHoveredUsageNodeIds: (nodeIds?: Iterable<string>) => void;
   setFlowViewportCenter: (position: FactoryNode["position"]) => void;
   recalculate: () => void;
   selectNode: (nodeId?: string) => void;
@@ -560,7 +560,7 @@ export const useFactoryStore = create<FactoryStore>((set, get) => ({
   selectedFlowResourceKey: undefined,
   hoveredNodeBottlenecks: false,
   selectedNodeBottlenecks: false,
-  hoveredUsageNodeId: undefined,
+  hoveredUsageNodeIds: undefined,
   selectedNodeId: undefined,
   selectedRecipeId: undefined,
   activePocketId: undefined,
@@ -925,8 +925,13 @@ export const useFactoryStore = create<FactoryStore>((set, get) => ({
   toggleNodeBottlenecks: () => {
     set((state) => ({ selectedNodeBottlenecks: !state.selectedNodeBottlenecks }));
   },
-  setHoveredUsageNodeId: (nodeId) => {
-    set({ hoveredUsageNodeId: nodeId });
+  setHoveredUsageNodeIds: (nodeIds) => {
+    if (!nodeIds) {
+      set({ hoveredUsageNodeIds: undefined });
+      return;
+    }
+    const next = nodeIds instanceof Set ? nodeIds : new Set(nodeIds);
+    set({ hoveredUsageNodeIds: next.size > 0 ? next : undefined });
   },
   setFlowViewportCenter: (position) => {
     set({ flowViewportCenter: position });


### PR DESCRIPTION
I added this as I wanted a way to quickly get a list of all of the machines I need to make.


Added a section to the Resources sidebar for machines.

Gives a list of all machines used in the current setup.
Sorts by energy tier, then number of machines then alphabetically.
If you hover over a machine type will highlight all machines of that type
If you double click will cycle through all machines of that type on this tier,
ie will not go into or out of pockets while cycling
If you select some machines then will only display those machines



Added a machine-roster test

Added a section to the A look around the planner help section to show people how to use this tab.

Added release number and changelog (no idea if this was wanted)

also fixed some random tests that were not functional. ie
```
expect(formatSlotRateOrNull(0.5, "item")).toBe("0.50/s"); to 
expect(formatSlotRateOrNull(0.5, "item")).toBe("0.5/s");
```
as I believe the functionality was changed to always reduce numbers but the test was not changed.

All tests run and I used the GTNH_DATASET_BACKEND_URL=https://gtnhplanner.com to test on a running system.

